### PR TITLE
Add disabling to scenes

### DIFF
--- a/application/models/scene.py
+++ b/application/models/scene.py
@@ -34,3 +34,4 @@ class SceneAction(BaseModel):
     action_param = BlobField(null=True)
 
     sequence_order = IntegerField(null=True)
+    job_id = IntegerField(null=True)

--- a/application/repository/reminder.py
+++ b/application/repository/reminder.py
@@ -1,5 +1,4 @@
 from application.models.reminder import Reminder
-from application.repository import user as User
 from application.utils.exception_handler import log_exception
 
 def get_reminder(id=None, user=None):

--- a/application/repository/scene.py
+++ b/application/repository/scene.py
@@ -1,5 +1,4 @@
 from application.models.scene import Scene
-from application.repository import user as User
 from application.utils.exception_handler import log_exception
 
 def get_scene(id=None, user=None):
@@ -41,5 +40,11 @@ def add_scene(user, name, description=None):
 
 def delete_scene(scene):
     scene.delete_instance()
+
+    return scene
+
+def update_enabled(scene, enabled):
+    scene.enabled = enabled
+    scene.save()
 
     return scene

--- a/application/repository/scene_action.py
+++ b/application/repository/scene_action.py
@@ -1,5 +1,4 @@
 from application.models.scene import Scene, SceneAction
-from application.repository import user as User
 from application.utils.exception_handler import log_exception
 
 def get_scene_action(id=None, scene=None, user=None):
@@ -61,6 +60,12 @@ def delete_scene_action(scene_action):
 
 def update_sequence_order(scene_action, order):
     scene_action.sequence_order = order
+    scene_action.save()
+
+    return scene_action
+
+def update_job_id(scene_action, job_id):
+    scene_action.job_id = job_id
     scene_action.save()
 
     return scene_action

--- a/application/routes/scene_editor.py
+++ b/application/routes/scene_editor.py
@@ -69,6 +69,8 @@ def add_action_to_sequence():
 
             if error:
                 return jsonify({'error': "Scheduling for scene actions was unsuccessful"}), 500
+            
+            SceneAction.update_job_id(scene_action, job.id)
 
     for action in scene.actions:
         if str(action.id) not in action_ids:
@@ -82,6 +84,7 @@ def delete_scene_action():
     action_id = data['scene_action_id']
     scene_action = SceneAction.get_scene_action(id=action_id)
 
+    scheduler.delete_job(scene_action.job_id)
     SceneAction.delete_scene_action(scene_action)
 
     return jsonify({'success': f'Scene action successfully deleted :O)'}), 200

--- a/application/templates/scene_editor.html
+++ b/application/templates/scene_editor.html
@@ -55,7 +55,7 @@
     <div style="text-align: center; margin-top: 50px;">
       <div id="editor" ondragover="allowDrop(event)">
         {% for action in sequence %}
-          <div class="scene-action-card" data="{{ action.device.name }} {{ action.action_type }} {{ action.start_time }}"></div>
+          <div class="scene-action-card" action-id="{{ action.id }}" editor-card="" data="{{ action.device.name }} {{ action.action_type }} {{ action.start_time }}"></div>
         {% endfor %}
       </div>
 
@@ -75,7 +75,7 @@
 
       {% for action in scene_actions %}
         <div style="width: 15%;" action-id="{{ action.id }}" class="scene-action-card" draggable="true" ondragstart="drag(event)" data="{{ action.device.name }} {{ action.action_type }} {{ action.start_time }}">
-          <button id="delete" class="button-81" role="button" scene_action_id="{{ action.id }}" style="margin-left: 10px; background-color: rgb(165, 96, 111); transform: scale(0.6);" onclick="deleteSceneAction(this)">
+          <button id="delete" class="button-81" role="button" scene_action_id="{{ action.id }}" style="margin: 0 0 0 10px; background-color: rgb(165, 96, 111); transform: scale(0.6);" onclick="deleteSceneAction(this)">
             <i class="fas fa-trash-alt"></i> <!-- trash can icon -->
           </button>
         </div>
@@ -166,44 +166,6 @@
     <div id="snackbar">Update successful :O)</div>
 
     <script>
-        // Function to allow dropping a scene action card into the editor
-        function allowDrop(event) {
-            event.preventDefault();
-        }
-
-        // Function to handle the drag start event
-        function drag(event) {
-            event.dataTransfer.setData("text", event.target.innerText);
-            const actionId = event.target.getAttribute("action-id");
-            event.dataTransfer.setData("action-id", actionId);
-        }
-
-        var sceneActions = [];
-        var count = 0;
-        const editor = document.getElementById("editor");
-
-        editor.addEventListener("drop", (event) => {
-          event.preventDefault();
-          count++;
-          const data = event.dataTransfer.getData("text");
-          const sceneActionCard = document.createElement("div");
-          sceneActionCard.className = "scene-action-card";
-          sceneActionCard.innerText = count + ". " + data;
-
-          event.currentTarget.appendChild(sceneActionCard);
-          const actionId = event.dataTransfer.getData("action-id");
-          sceneActions.push(actionId);
-        });
-
-        function clearEditor() {
-          sceneActions = []
-          count = 0;
-
-          while (editor.firstChild) {
-              editor.removeChild(editor.firstChild);
-          }
-        }
-
         function addSequence(button) {
           document.body.style.cursor = 'wait';
           sceneId = button.getAttribute("scene_id")
@@ -360,6 +322,11 @@
             }
         });
 
+        var order = 0;
+        var count = 0;
+        var sceneActions = [];
+        const editor = document.getElementById("editor");
+
         window.onload = function() {
           const sceneActionAddMessage = localStorage.getItem('sceneActionAddMessage');
           const sceneActionDeleteMessage = localStorage.getItem('sceneActionDeleteMessage');
@@ -372,12 +339,20 @@
             localStorage.removeItem('sceneActionDeleteMessage');
           }
 
-          action_cards = document.getElementsByClassName("scene-action-card")
+          var action_cards = document.getElementsByClassName("scene-action-card");
 
           for (const card of action_cards) {
             data = card.getAttribute("data").split(" ")
             start = data[3].substring(0, 5);
-            description = data[0] + " " + data[1] + " @ " + start;
+
+            if (!card.hasAttribute("editor-card")) {
+              description = data[0] + " " + data[1] + " @ " + start;
+            } else {
+              order++;
+              count++;
+              description = order + ". " + data[0] + " " + data[1] + " @ " + start;
+              sceneActions.push(card.getAttribute("action-id"))
+            }
             card.insertAdjacentHTML("afterbegin", description);
           }
 
@@ -392,6 +367,40 @@
 
           setInterval(() => {func()}, 30000);
         };
+
+        // Function to allow dropping a scene action card into the editor
+        function allowDrop(event) {
+            event.preventDefault();
+        }
+
+        // Function to handle the drag start event
+        function drag(event) {
+            event.dataTransfer.setData("text", event.target.innerText);
+            const actionId = event.target.getAttribute("action-id");
+            event.dataTransfer.setData("action-id", actionId);
+        }
+
+        editor.addEventListener("drop", (event) => {
+          event.preventDefault();
+          count++;
+          const data = event.dataTransfer.getData("text");
+          const sceneActionCard = document.createElement("div");
+          sceneActionCard.className = "scene-action-card";
+          sceneActionCard.innerText = count + ". " + data;
+
+          event.currentTarget.appendChild(sceneActionCard);
+          const actionId = event.dataTransfer.getData("action-id");
+          sceneActions.push(actionId);
+        });
+
+        function clearEditor() {
+          sceneActions = []
+          count = 0;
+
+          while (editor.firstChild) {
+              editor.removeChild(editor.firstChild);
+          }
+        }
 
         function updateSnackbar(message, color) {
             var x = document.getElementById("snackbar");

--- a/application/templates/scenes.html
+++ b/application/templates/scenes.html
@@ -169,6 +169,31 @@
         });
       }
 
+      function toggleScene(checkbox) {
+        var scene_id = checkbox.getAttribute("scene_id");
+
+        // Send an HTTP PUT request to the backend to toggle the scene
+        fetch('/scenes/' + scene_id + '/toggle', {
+          method: 'PUT',
+          body: JSON.stringify({
+            enabled: checkbox.checked
+          }),
+          headers: {
+            'Content-Type': 'application/json'
+          }
+        })
+        .then((response) => {
+          return response.json();
+        })
+        .then((data) => {
+          updateSnackbar(data.success, "rgb(121, 196, 137)")
+        })
+        .catch((error) => {
+          // Handle any errors
+          updateSnackbar(error, "red")
+        });
+      }
+
       function deleteScene(button) {
         var scene_id = button.getAttribute('scene_id');
         var scene_name = button.getAttribute('scene_name');

--- a/application/templates/sensors.html
+++ b/application/templates/sensors.html
@@ -228,7 +228,6 @@
           if (!response.error) {
             var dropdown = $("#sensorDropDown");
             dropdown.empty();
-            console.log(response)
             $.each(response, function(key, value) {
               dropdown.append($("<option></option>").attr("value", value).text(value));
             });


### PR DESCRIPTION
# Summary
We can now disable scenes. This will unschedule scene actions that are a part of this scene.

## What I did here
- Add a job_id reference to scene schema
- Add route to toggle scenes
- Fixed frontend to properly display ordering of scene actions in the editor
- Fixed frontend to properly append scene actions to editor when it is not empty

## How to test
-
