### PR TITLE
Adjust Scene Action Start/End

### DIFF
--- a/application/routes/scene_editor.py
+++ b/application/routes/scene_editor.py
@@ -73,8 +73,11 @@ def schedule_action_sequence():
     action_ids = data['scene_actions']
     scene = Scene.get_scene(id=scene_id)
 
+    if len(action_ids) == 0:
+         return jsonify({'error': "Scene must contain at least one action"}), 400
+
     for action_id in action_ids:
-        scene_action = SceneAction.get_scene_action(id=action_id)
+        scene_action = SceneAction.get_scene_action(id=int(action_id))
         SceneAction.update_enabled(scene_action, True)
 
         if scene.enabled:
@@ -84,6 +87,10 @@ def schedule_action_sequence():
                 return jsonify({'error': "Scheduling for scene actions was unsuccessful"}), 500
             
             SceneAction.update_job_id(scene_action, job.id)
+
+    for action in scene.actions:
+        if str(action.id) not in action_ids:
+            SceneAction.update_enabled(action, False)
 
     return jsonify({'success': 'Scene actions successfully scheduled'}), 200
 

--- a/application/routes/scenes.py
+++ b/application/routes/scenes.py
@@ -50,8 +50,8 @@ def toggle_scene(scene_id):
         if not enabled:
             scheduler.delete_job(scene_action.job_id)
         else:
-            job = scheduler.schedule_scene_action(scene_action)
-            SceneAction.update_job_id(scene_action, job.id)
+            SceneAction.adjust_start_end_time(scene_action)
+            scheduler.schedule_scene_action(scene_action, now=True)
 
     return jsonify({'success': f'{scene.name} scene toggled successfully :O)'}), 200
 

--- a/application/templates/scene_editor.html
+++ b/application/templates/scene_editor.html
@@ -198,11 +198,6 @@
             }
             })
             .catch((error) => {
-            // Clear the input boxes
-            sensor.value = "";
-            actionType.value = "";
-            actionParam.value = "";
-
             document.body.style.cursor = 'default';
             updateSnackbar(error, "red");
             })
@@ -254,11 +249,6 @@
             }
             })
             .catch((error) => {
-            // Clear the input boxes
-            sensor.value = "";
-            actionType.value = "";
-            actionParam.value = "";
-
             document.body.style.cursor = 'default';
             updateSnackbar(error, "red");
             })


### PR DESCRIPTION
# Summary
Previously, when disabling a scene, the scene's actions would not be adjusted to start and end at the later date when the scene is re-enabled. Now this should work properly.

## What I did here
- Added a function in the `scene_action` repo to adjust scene action start and end times to the current day.
- Called above function in the `start()` function of the scheduler. This ensures that all scene actions are properly adjusted upon startup.

## How to test
-
