### PR TITLE
Add setting for drawing extra objects

### DIFF
--- a/application/routes/home.py
+++ b/application/routes/home.py
@@ -44,3 +44,23 @@ def get_camera_data(cam):
     else:
         detection = "ON"
     return jsonify({'success': detection}), 200
+
+@bp.route("/get-conf-threshold")
+def get_conf_threshold():
+    conf_threshold = object_detection.min_conf_threshold
+    return jsonify({'success': conf_threshold}), 200
+
+@bp.route("/get-message-cooloff")
+def get_message_cooloff():
+    message_cooloff = object_detection.message_cooloff.total_seconds()
+    return jsonify({'success': message_cooloff}), 200
+
+@bp.route("/get-draw-extra-objects")
+def get_extra_bounding():
+    is_extra = object_detection.draw_extra_objects
+
+    if is_extra:
+        detection = "ON"
+    else:
+        detection = "OFF"
+    return jsonify({'success': detection}), 200

--- a/application/routes/settings.py
+++ b/application/routes/settings.py
@@ -1,6 +1,5 @@
 import datetime
 
-from application import app
 from application.repository import user as User
 from application.services import security as vault
 from application.services.telegram import telegram
@@ -26,7 +25,8 @@ def settings():
     return render_template("settings.html", users=names, ids=ids, telegram_statuses=tg_status,
                             chat_ids=tg_chat_ids, sms_statuses=sms_status, phone_nums=numbers,
                             min_conf=object_detection.min_conf_threshold,
-                            message_cooloff=cooloff, cams=cameras, cam_statuses=cameras_status)
+                            message_cooloff=cooloff, cams=cameras, cam_statuses=cameras_status,
+                            draw_extra_objects=object_detection.draw_extra_objects)
 
 @bp.route("/get_bot_username")
 def get_bot_username():
@@ -75,6 +75,14 @@ def update_message_cooloff():
     cooloff_seconds = int(data['new_cooloff'])
     new_cooloff = datetime.timedelta(seconds=cooloff_seconds)
     object_detection.message_cooloff = new_cooloff
+
+    return jsonify({'success': True}), 200
+
+@bp.route("/settings/draw-extra-objects", methods=["PUT"])
+def update_extra_objects():
+    data = request.get_json()
+    draw_extra_objects = data['draw_extra_objects']
+    object_detection.draw_extra_objects = draw_extra_objects
 
     return jsonify({'success': True}), 200
 

--- a/application/services/video/object_detection.py
+++ b/application/services/video/object_detection.py
@@ -48,6 +48,9 @@ message_time = datetime.datetime(1900, 1, 1)
 # Time-delta of the transmission of consecutive notification messages
 message_cooloff = datetime.timedelta(seconds=15)
 
+# Indicate to put bounding boxes on all objects or only people
+draw_extra_objects = False
+
 # Initialize frame rate calculation
 frame_rate_calc = 1
 freq = cv2.getTickFrequency()
@@ -158,9 +161,13 @@ def detection():
             # Loop over all detections and draw detection box if confidence is above minimum threshold
             for i in range(len(scores)):
                 if ((scores[i] > min_conf_threshold) and (scores[i] <= 1.0)):
+                    object_name = labels[int(classes[i])]
 
                     # Get bounding box coordinates and draw box
-                    object_name = draw_detection_box(i, frame, labels, boxes, classes, scores)
+                    if not draw_extra_objects and object_name == "person":
+                        object_name = draw_detection_box(i, frame, labels, boxes, classes, scores)
+                    elif draw_extra_objects:
+                        object_name = draw_detection_box(i, frame, labels, boxes, classes, scores)
 
                     # Handle notifications based on detection results
                     prepare_notification(object_name, frame, idx)

--- a/application/static/styles.css
+++ b/application/static/styles.css
@@ -6,7 +6,7 @@ html, body {
 body {
   background: url('main_background.png');
   background-repeat: no-repeat;
-  background-size: 150% 305%;
+  background-size: 150% 330%;
   backdrop-filter: blur( 16.5px );
   margin: 0;
   font-family: Arial, sans-serif;
@@ -63,9 +63,12 @@ body {
 
 /* Navigation styles */
 .logo {
+  border-radius: 50%;
+  box-shadow:inset 20px 0px 32px 0px rgb(84, 84, 84, 0.2);
   cursor: pointer;
   width: auto;
   height: 130px;
+  transform: scale(0.9);
   float: left;
   margin: auto 2px;
   transition: transform 0.2s ease-in-out;
@@ -143,32 +146,36 @@ h1 {
   text-align: center;
   font-family: 'Segoe UI', monospace;
 }
+#feed-div {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  position: relative;
+}
+#image-container {
+  text-align: center;
+  margin: auto;
+}
 .marginauto {
+  height: auto;
   box-shadow: 0 8px 32px 10px rgba(12, 15, 54, 0.37);
-  margin: 50px auto 20px auto;
+  margin: 0 auto 20px auto;
   display: block;
 }
 .indicator {
-  box-shadow: 0 8px 32px 0 rgba( 31, 38, 135, 0.37 );
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px;
+  display: block;
+  position: relative;
+  top: 42px;
+  left: 0;
+  border: 2px solid #414141;
+  padding: 10px 10px 10px 10px;
   background-color: #e8e8e8;
-  border-radius: 8px;
+  border-radius: 25%;
   font-size: 16px;
   font-weight: bold;
   text-align: center;
   transition: background-color 0.3s ease;
   width: fit-content;
-  margin: 0 auto;
-  transform: scale(1.1);
-}
-#detection-text {
-  margin-right: 5px;
-}
-#detection-state {
-  font-size: 18px;
 }
 
 /* FEED BUTTON */
@@ -218,7 +225,7 @@ h1 {
   margin: 15px 0;
   transition: all .1s cubic-bezier(.4, 0, .2, 1);
   background: #e8e8e8;
-  box-shadow: 0 8px 32px 0 rgba( 31, 38, 135, 0.37 );
+  box-shadow: 0 3px 3px 0 rgba( 31, 38, 135, 0.37 );
   backdrop-filter: blur( 16.5px );
   -webkit-backdrop-filter: blur( 16.5px );
   border: 1px solid rgba( 255, 255, 255, 0.18 );

--- a/application/templates/index.html
+++ b/application/templates/index.html
@@ -71,19 +71,38 @@
 
   <div class="content">
     <div>
-      <h1 class="h1">Surveillance Feed</h1>
+      <h1 style="margin: 50px 0 50px 0;" class="h1">Surveillance Feed</h1>
     </div>
 
-    <div>
-      <img id="feed" style="zoom: 135%;" src="{{ url_for('home.video_feed', cam='Driveway') }}" class = "marginauto" alt="centered image">
+    <div id="feed-div">
+      <div id="image-container">
+        <span id="detection-indicator" class="indicator">
+          <span id="detection-text"><i class="fas fa-eye"></i></span>
+        </span>
+        <img id="feed" style="zoom: 135%; border-radius: 8px;" src="{{ url_for('home.video_feed', cam='Driveway') }}" class="marginauto" alt="centered image">
+      </div>
     </div>
 
-    <div id="detection-indicator" class="indicator">
-      <span id="detection-text">Detection: </span>
-      <span id="detection-state">-</span>
+    <div style="text-align: center; margin-top: 50px;">
+      <span style="border-radius: 8px; background-color: rgb(212, 212, 212); padding: 10px; font-weight: bold; margin-right:5px;">
+        <span id="message-cooloff-text">Message Cooloff: </span>
+        <span id="message-cooloff-state">-</span>
+      </span>
+
+      <span style="border-radius: 8px; background-color: rgb(212, 212, 212); padding: 10px; font-weight: bold; margin-right: 5px;">
+        <span id="min-conf-thresh-text">Min Conf Thresh: </span>
+        <span id="min-conf-thresh-state">-</span>
+      </span>
+
+      <span style="border-radius: 8px; background-color: rgb(212, 212, 212); padding: 10px; font-weight: bold; margin-right: 5px;">
+        <span id="extra-objects-text">Extra Objects: </span>
+        <span id="extra-objects-state">-</span>
+      </span>
     </div>
 
-    <div style="display: flex; align-items: center; justify-content: center; margin: 70px auto auto auto;">
+    <br>
+
+    <div style="display: flex; align-items: center; justify-content: center; margin: 100px auto auto auto;">
       <button id="next" class="button-81" style="font-size: 1.5rem;" role="button" onclick="change_camera(); submitPoll(); getDetectionState()">Next Camera</button>
     </div>
   </div>
@@ -97,6 +116,9 @@
   <script>
       window.onload = function() {
         getDetectionState()
+        getMessageCooloff()
+        getMinConfThreshold()
+        getExtraObjectsState()
       };
 
       function getDetectionState() {
@@ -108,18 +130,50 @@
           return response.json();
         })
         .then((data) => {
-          var stateText = document.getElementById("detection-state");
-          stateText.innerText = data.success;
+          var detectionText = document.getElementById("detection-text");
 
           var indicator = document.getElementById("detection-indicator");
 
           if (data.success === "ON") {
             indicator.style.backgroundColor = "rgb(121, 196, 137)";
-            indicator.style.color = "white";
+            detectionText.innerHTML = "<i class='fas fa-eye'></i>";
           } else {
             indicator.style.backgroundColor = "#F2F2F2";
-            indicator.style.color = "black";
+            detectionText.innerHTML = "<i class='fas fa-eye-slash'></i>";
           }
+        })
+      }
+
+      function getMessageCooloff() {
+        fetch('get-message-cooloff')
+        .then((response) => {
+          return response.json();
+        })
+        .then((data) => {
+          var stateText = document.getElementById("message-cooloff-state");
+          stateText.innerText = data.success;
+        })
+      }
+
+      function getMinConfThreshold() {
+        fetch('get-conf-threshold')
+        .then((response) => {
+          return response.json();
+        })
+        .then((data) => {
+          var stateText = document.getElementById("min-conf-thresh-state");
+          stateText.innerText = data.success;
+        })
+      }
+
+      function getExtraObjectsState() {
+        fetch('get-draw-extra-objects')
+        .then((response) => {
+          return response.json();
+        })
+        .then((data) => {
+          var stateText = document.getElementById("extra-objects-state");
+          stateText.innerText = data.success;
         })
       }
   </script>

--- a/application/templates/settings.html
+++ b/application/templates/settings.html
@@ -16,6 +16,7 @@
     </script>
 
     <link rel="stylesheet" href="../static/styles.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
   </head>
 
   <body>
@@ -69,7 +70,9 @@
           </tr>
           <tbody>
             <tr>
-              <td><b>Message Cool-Off</b><br>(Seconds between consecutive messages)</td>
+              <td title="Delay in seconds between messages">
+                <b>Message Cool-Off <i class="tooltip fas fa-question-circle"></i></b>
+              </td>
               <td>
                 <label for="message_cooloff"></label>
                 <input type="range" id="message_cooloff" name="message_cooloff" class="slider" min="15" max="180" step="15" value="{{ message_cooloff }}" style="width: 80px;">
@@ -91,7 +94,9 @@
           </tr>
           <tbody>
             <tr>
-              <td><b>Minimum Confidence Threshold</b><br>(Lowest percentage for detection results)</td>
+              <td title="Detection results below this are omitted">
+                <b>Minimum Confidence Threshold <i class="tooltip fas fa-question-circle"></i></b>
+              </td>
               <td>
                 <label for="conf_threshold"></label>
                 <input type="range" id="conf_threshold" name="conf_threshold" class="slider" min="0.1" max="0.9" step="0.1" value="{{ min_conf }}" style="width: 80px;">
@@ -100,7 +105,10 @@
               </td>
             </tr>
             <tr>
-              <td style="vertical-align:top;"><b>Enable/Disable Detection</b><br>(Select cameras to run detection on)<br><br>Note:<br>Optimal performance is 3 cam max</td>
+              <td title="Select cameras to run detection on.
+Optimal performance is 3 cam max.">
+                <b>Enable Camera Detection <i class="tooltip fas fa-question-circle"></i></b>
+              </td>
               <td>
                 <div id="tableContainer-1">
                   <div id="tableContainer-2">
@@ -124,6 +132,15 @@
                 </div>
               </td>
             </tr>
+            <tr>
+              <td title="Enable detection of other objects.
+People are always detected.">
+                <b>Draw Extra Objects <i class="tooltip fas fa-question-circle"></i></b>
+              </td>
+              <td>
+                <input type="checkbox" class="checkbox" {% if draw_extra_objects %}checked{% endif %} onclick="updateDrawExtraObjects(this)">
+              </td>
+            </tr>
           </tbody>
         </table>
       </div>
@@ -138,6 +155,17 @@
     <div id="snackbar">Update successful :O)</div>
 
     <script>
+      $("td[title]").click(function () {
+        var $title = $(this).find(".title");
+        if (!$title.length) {
+          $(this).append('<div class="title" style="font-size: 20px; padding: 5px; white-space: pre;">' + $(this).attr("title") + '</div>');
+          $(this).css('z-index', 2);
+        } else {
+          $title.remove();
+          $(this).css('z-index', 0);
+        }
+      });
+
       function updateNotifications(checkbox, service) {
         var user = checkbox.getAttribute('first-name');
         var user_id= checkbox.getAttribute('user-id');
@@ -192,6 +220,28 @@
           let msg = ""
           response.ok ? msg = `\"${cam}\" camera detection updated :O)` :
                         msg = `Failed to update \"${cam}\" camera detection :O(`
+          updateSnackbar(msg)
+        })
+        .catch((error) => {
+          // Handle any errors
+          updateSnackbar(error)
+        });
+      }
+
+      function updateDrawExtraObjects(checkbox) {
+        fetch('/settings/draw-extra-objects', {
+          method: 'PUT',
+          body: JSON.stringify({
+            draw_extra_objects: checkbox.checked
+          }),
+          headers: {
+            'Content-Type': 'application/json'
+          }
+        })
+        .then((response) => {
+          let msg = ""
+          response.ok ? msg = `Extra objects updated :O)` :
+                        msg = `Failed to update extra objects :O(`
           updateSnackbar(msg)
         })
         .catch((error) => {

--- a/application/templates/stats.html
+++ b/application/templates/stats.html
@@ -23,7 +23,7 @@
         <h1 class="h1">Realtime Stats</h1>
       </div>
 
-      <p id="stats" style="text-align: center; font-size: 25px;"><br></p>
+      <p id="stats" style="text-align: center; font-size: 25px; margin-top: 100px;"><br></p>
     </div>
 
     {% include 'includes/footer.html' %}


### PR DESCRIPTION
# Summary
We can now enable/disable the drawing of bounding boxes around objects that are not people. This will help clear up surveillance feed footage and snapshots where people are occluded by too many bounding boxes.

## What I did here
- Added frontend `draw extra objects` setting for enabling/disabling bounding boxes on objects apart from people.
- Added routes to facilitate `draw extra objects` setting and existing video settings.
- Display video settings (`minimum confidence threshold`, `message cooloff`, and `extra objects`) on home screen under surveillance feed.
- Added clickable question marks next to settings that display more info.
- Moved detection indicator to top left corner of video feed. Changed text to; eyeball when on, eyeball with a slash when off.

## How to test
-
